### PR TITLE
Change font from Bahnschrift to Open Sans

### DIFF
--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -1,41 +1,42 @@
 ﻿@import url("open-iconic/font/css/open-iconic-bootstrap.min.css");
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
 
 html,
 body {
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
 }
 
 h2{
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
     text-align: center;
     margin-top: 30px;
     margin-bottom: 30px;
 }
 
 h3{
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
     margin-bottom: 20px;
 }
 
 h4{
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
     margin-bottom: 15px;
 }
 
 a {
     font-size: 18px;
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
     color: #16A085;
 }
 
 p{
     font-size: 18px;
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
 }
 
 li{
     font-size: 18px;
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
 }
 
 section{
@@ -49,7 +50,7 @@ section{
 .btn{
     margin-left: 5px;
     font-size: 18px;
-    font-family: Bahnschrift;
+    font-family: 'Open Sans', sans-serif;
 }
 
 .btn-light {


### PR DESCRIPTION
## Description of Change

Due to macOS missing `Bahnschrift` as a base font, the current website does not style the fonts correctly. To battle this, I have updated to use the Open Sans google font (similar to the existing DotNetNotts site) using the google import.

## Evidence Of Change

### Current
![HomePage_Current](https://user-images.githubusercontent.com/6100643/105751498-f8fe6f00-5f3d-11eb-9585-701a9148b1ae.png)

### Updated
![HomePage_Updated](https://user-images.githubusercontent.com/6100643/105751714-4f6bad80-5f3e-11eb-830a-43189bc925cb.png)

## Linked Issue

This is to resolve issue #86 
