### PR TITLE
Update project to use dotnet 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  # Enable version updates for Docker
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  # Enable version updates for nuget
   - package-ecosystem: 'nuget'
     directory: '/'
     schedule:
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: 'weekly'
 
-  # Enable version updates for Docker
+  # Enable version updates for git actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/build_dotnetnotts.yml
+++ b/.github/workflows/build_dotnetnotts.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Clean
       run: dotnet clean --configuration Release && dotnet nuget locals all --clear

--- a/.github/workflows/main_dotnetnotts.yml
+++ b/.github/workflows/main_dotnetnotts.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
       
     - name: Restore dependencies
       run: dotnet restore

--- a/dotnetnotts.csproj
+++ b/dotnetnotts.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.1" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.101",
+    "version": "8.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/tests/dotnetnotts.tests.unit/dotnetnotts.tests.unit.csproj
+++ b/tests/dotnetnotts.tests.unit/dotnetnotts.tests.unit.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="bunit" Version="1.25.3" />
+        <PackageReference Include="bunit" Version="1.26.64" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="System.Linq" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.6.5" />
@@ -17,8 +17,8 @@
     
     <!-- Explicit PackageReferences for Vulnerabilities -->
     <ItemGroup>
-        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Description of Change

- Updates project and test project to use dotnet version 8
- Updates dependencies to the latest
- Updates build configuration to utilise dotnet 8
- Add git actions to Dependabot to keep them up to date

## Evidence Of Change

![image](https://github.com/dotnetnotts/dotnetnotts-web/assets/6100643/0d33a616-0ca9-42f8-9187-d87e66c06264)

## Linked Issue

#270 
