### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_dotnetnotts.yml
+++ b/.github/workflows/main_dotnetnotts.yml
@@ -2,6 +2,8 @@
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 
 name: Build and to Azure Web App - dotnetnotts
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dotnetnotts/dotnetnotts-web/security/code-scanning/3](https://github.com/dotnetnotts/dotnetnotts-web/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to specific jobs). In this case, since there is only one job, adding it at the root is simplest and most effective. You should insert the following block after the `name:` field and before the `on:` field in `.github/workflows/main_dotnetnotts.yml`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
