### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_dotnetnotts.yml
+++ b/.github/workflows/build_dotnetnotts.yml
@@ -1,4 +1,6 @@
 name: Build - dotnetnotts
+permissions:
+  contents: read
 
 on: [pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/dotnetnotts/dotnetnotts-web/security/code-scanning/1](https://github.com/dotnetnotts/dotnetnotts-web/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to read repository contents but not write to them. You should insert the following block after the `name` and before the `on` key:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required. Only the workflow YAML file needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
